### PR TITLE
ci(ingest): do not require TELEGRAM_TOKEN for AI ingest; require only for bot

### DIFF
--- a/bot_enhanced_v3.py
+++ b/bot_enhanced_v3.py
@@ -24,7 +24,8 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Загружаем настройки
-settings = load_settings()
+# Для бота — токен обязателен
+settings = load_settings(require_bot=True)
 
 # Инициализация базы данных
 init_engine(settings.database_url)

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ def _parse_admin_ids(value: str | None) -> set[int]:
     return ids
 
 
-def load_settings() -> Settings:
+def load_settings(require_bot: bool = False) -> Settings:
     # Ensure .env.local is loaded even if called from different CWD
     load_dotenv(_BASE_DIR / ".env.local", encoding="utf-8-sig")
 
@@ -60,7 +60,8 @@ def load_settings() -> Settings:
     except ValueError:
         default_radius_km = 4.0
 
-    if not telegram_token:
+    # Требовать токен только в режиме бота
+    if require_bot and not telegram_token:
         raise RuntimeError("TELEGRAM_TOKEN is required")
     if not database_url:
         raise RuntimeError("DATABASE_URL is required (e.g. postgres://user:pass@host:port/db)")


### PR DESCRIPTION
   ## Fix: TELEGRAM_TOKEN not required for AI ingest in CI
   
   ### Problem
   GitHub Actions CI failed with `RuntimeError: TELEGRAM_TOKEN is required` in "Run AI ingest" step.
   
   ### Solution
   - Added `require_bot` parameter to `load_settings()`
   - Bot requires TELEGRAM_TOKEN (`require_bot=True`)
   - AI ingest works without TELEGRAM_TOKEN (`require_bot=False`)
   - Maintains backward compatibility
   
   ### Testing
   - ✅ Local ingest dry-run works without TELEGRAM_TOKEN
   - ✅ Bot still requires TELEGRAM_TOKEN
   - ✅ No breaking changes to existing functionality